### PR TITLE
Branding: use "Aspire" instead of ".NET Aspire"

### DIFF
--- a/ChatApp.AppHost/ChatApp.AppHost.csproj
+++ b/ChatApp.AppHost/ChatApp.AppHost.csproj
@@ -10,8 +10,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aspire.Hosting.AppHost" Version="8.0.2" />
-    <PackageReference Include="Aspire.Hosting.Azure.CognitiveServices" Version="8.0.2" />
+    <PackageReference Include="Aspire.Hosting.AppHost" Version="13.4.6" />
+    <PackageReference Include="Aspire.Hosting.Azure.CognitiveServices" Version="13.4.6" />
     <PackageReference Include="Aspire.Hosting.NodeJs" Version="8.0.2" />
   </ItemGroup>
 

--- a/ChatApp.AppHost/ChatApp.AppHost.csproj
+++ b/ChatApp.AppHost/ChatApp.AppHost.csproj
@@ -1,4 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
+  <Sdk Name="Aspire.AppHost.Sdk" Version="13.4.6" />
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>

--- a/ChatApp.ServiceDefaults/Extensions.cs
+++ b/ChatApp.ServiceDefaults/Extensions.cs
@@ -9,7 +9,7 @@ using OpenTelemetry.Trace;
 
 namespace Microsoft.Extensions.Hosting;
 
-// Adds common .NET Aspire services: service discovery, resilience, health checks, and OpenTelemetry.
+// Adds common Aspire services: service discovery, resilience, health checks, and OpenTelemetry.
 // This project should be referenced by each service project in your solution.
 // To learn more about using this project, see https://aka.ms/dotnet/aspire/service-defaults
 public static class Extensions

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # Aspire Sample Application
 
-Welcome to the Aspire Sample Application. This project is a comprehensive example of a chat application built with .NET Aspire, Semantic Kernel, and the `@microsoft/ai-chat-protocol` package. The frontend of the application is developed using React and Vite.
+Welcome to the Aspire Sample Application. This project is a comprehensive example of a chat application built with Aspire, Semantic Kernel, and the `@microsoft/ai-chat-protocol` package. The frontend of the application is developed using React and Vite.
 
 ## Overview
 
 The application consists of 2 main Projects:
 
-- `ChatApp.WebApi`: This is a .NET Web API that handles chat interactions, powered by .NET Aspire and Semantic Kernel. It provides endpoints for the chat frontend to communicate with the chat backend. The `@microsoft/ai-chat-protocol` package is used to handle chat interactions, including streaming and non-streaming requests.
+- `ChatApp.WebApi`: This is a .NET Web API that handles chat interactions, powered by Aspire and Semantic Kernel. It provides endpoints for the chat frontend to communicate with the chat backend. The `@microsoft/ai-chat-protocol` package is used to handle chat interactions, including streaming and non-streaming requests.
 
 - `ChatApp.React`: This is a React app that provides the user interface for the chat application. It is built using Vite, a modern and efficient build tool. It uses the `@microsoft/ai-chat-protocol` package to handle chat interactions, allowing for flexible communication with the chat backend.
 


### PR DESCRIPTION
## Use "Aspire" branding and update to the latest release (13.4.6)

Aspire was rebranded from **".NET Aspire"** to simply **"Aspire"**, and the latest release is **13.4.6** ([aspire.dev](https://aspire.dev)). This PR updates this sample accordingly.

### Branding
- Replaced `.NET Aspire` → `Aspire` in prose/docs.
- **Left unchanged** references tied to a specific older release (e.g. ".NET Aspire 9.4", ".NET Aspire 8.0"), since that was the product name at that version. Historical notes/changelogs are also untouched. `ASP.NET` text is unaffected.

### Versions
- Bumped official `Aspire.*` packages and `Aspire.AppHost.Sdk` to **13.4.6**.
- Left as-is: AI integration packages (`Aspire.Azure.AI.OpenAI`, `Aspire.Azure.AI.Inference`) — no stable 13.x exists and the preview build requires a newer runtime than this sample targets; `Aspire.Hosting.NodeJs` (no 13.x release); `CommunityToolkit.Aspire.*` (separate versioning).

> Opened as a **draft** for maintainer review. A cross-major bump may require small code adjustments to build — please validate. Part of a coordinated branding + version refresh.
